### PR TITLE
gke deployment updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,5 +148,6 @@ dump.rdb
 
 # Generated helm
 marqo-helm_manifest.yaml
-*.yaml
 
+out/
+vars.env

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ dump.rdb
 
 # Generated helm
 marqo-helm_manifest.yaml
+*.yaml
+

--- a/GKE/README.md
+++ b/GKE/README.md
@@ -8,7 +8,7 @@ This guide provides instructions on how to deploy Marqo on GKE using Kubernetes 
 
 - A Google Cloud account and a project.
 - Google Cloud SDK (`gcloud`) installed and configured.
-- Once gcloud is installed, add the gke-gcloud-auth-plugin e.g. `> gcloud components install gke-gcloud-auth-plugin`
+- The gcloud plugin gke-gcloud-auth-plugin installed: ```gcloud components install gke-gcloud-auth-plugin```
 - Kubernetes command-line tool (`kubectl`) installed.
 - Helm installed.
 
@@ -22,34 +22,40 @@ Before executing the setup.sh script, ensure your GCP quotas have capacity for t
 
 ## Deployment Steps
 
-1. **Clone the Repository:**
-   Ensure you have the Marqo on GCP repository cloned to your local machine. This repository contains the necessary Helm chart and the `setup.sh` script.
+1. **Clone the Repository:**</br>
+   Ensure you have the Marqo on Kubernetes repository cloned to your local machine. This repository contains the necessary Helm chart and the `setup_gke.sh` script.
 
    ```bash
    git clone git@github.com:marqo-ai/marqo-on-kubernetes.git
    cd marqo-on-kubernetes
    ```
-
-2. **Run the Setup Script:**
-   First authorize the gcloud CLI:
-
+   
+2. **Set Envars:**</br>
+   Copy GKE/vars_template.env to the same dir and name it vars.env e.g.
    ```bash
-   gcloud auth login
+   cp ./GKE/vars_template.env ./GKE/vars.env
    ```
-   The `setup.sh` script will set up your GCP environment, create a Kubernetes cluster, and configure the necessary node pools.
-
-   Before running the setup.sh script, review and customize the following variables to match your GCP environment:
-
+   Edit vars.env and set the variables with real values to match your GCP environment:
    - **PROJECT_ID**: Set to your GCP project ID.
    - **APP_INSTANCE_NAME**: Name your application instance.
    - **CLUSTER**: Define your Kubernetes cluster name.
    - **REGION** and **ZONE**: Specify your preferred GCP region and zone.
    - **INSTALL_GPU:** If deploying with GPU support, set INSTALL_GPU=true otherwise false.
+   </br></br>
 
+3. **Authorize the gcloud CLI :**
+   ```bash
+   gcloud auth login
+   ```
+   Note: It should only be necessary to do this once, but nothing will break if it's done multiple times, so if 
+   you run into trouble, run it again just in case</br></br>
+
+4. **Run the Setup Script:**</br>
+   The `setup_gke.sh` script will set up your GCP environment, create a Kubernetes cluster, and configure the necessary node pools.
 
    Run the script:
    ```bash
-   ./GKE/setup_gke.sh
+   sh ./GKE/setup_gke.sh deploy
    ```
 
    This script performs the following actions:
@@ -58,9 +64,10 @@ Before executing the setup.sh script, ensure your GCP quotas have capacity for t
    - Creates a Kubernetes cluster.
    - Configures various node pools for different purposes.
    - Applies necessary Kubernetes configurations.
-
-3. **Kubernetes Cluster Validation:**
-   Execution of the `setup.sh` script includes the following automated steps:
+   </br></br>
+   
+5. **Kubernetes Cluster Validation:**</br>
+Execution of `setup_gke.sh deploy` includes the following automated steps:
    - Generation of the Helm chart.
    - Deployment of the generated chart onto the Kubernetes cluster.
    Typically, it takes about 3 to 5 minutes for Marqo to become operational within the cluster. To verify the health of the Marqo pod in the cluster, use:
@@ -68,12 +75,22 @@ Before executing the setup.sh script, ensure your GCP quotas have capacity for t
    kubectl get pods --all-namespaces -w
    ```
    Ensure that all pods reach the `Running` state before proceeding.
+   </br></br>
 
-4. **Test Marqo endpoint:**
-
+6. **Test Marqo endpoint:**</br>
+NOTE: the following test/s presume that MARQO_CLUSTER_IP has been exported as an envar 
+and contains the IP address of the marqo cluster that was deployed. 
+This occurs during deployment but the envar won't survive exiting the session the cluster was deployed in.
+MARQO_CLUSTER_IP is therefore also written to `out/marqo_cluster_ip_gke.env` 
+so if necessary you can re-export it to the environment with
+```bash
+  set -a
+  source out/marqo_cluster_ip.env
+  set +a
 ```
-export MARQO_CLUSTER_IP=$(kubectl get svc marqo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
+To run a simple test
+```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install marqo
@@ -81,18 +98,10 @@ python test_marqo.py
 ```
 
 ## Additional Configuration
-
-- **GPU Nodes:** If you plan to use GPU nodes, uncomment the relevant section in the `setup.sh` script before running it. This will create a node pool with GPU capabilities.
-
-- **Custom Configurations:** Modify the Helm chart values or the `setup.sh` script as needed for custom configurations.
+- **Custom Configurations:** Modify the Helm chart values or the `setup_gke.sh` script as needed for custom configurations.
 
 ## Cleanup
-
 To delete the Kubernetes cluster and clean up the resources, run:
-
 ```bash
-gcloud container clusters delete "$CLUSTER" --quiet
+sh ./GKE/setup.sh destroy
 ```
-
-Replace `"$CLUSTER"` with the name of your cluster if different from the one set in the script.
-

--- a/GKE/README.md
+++ b/GKE/README.md
@@ -8,6 +8,7 @@ This guide provides instructions on how to deploy Marqo on GKE using Kubernetes 
 
 - A Google Cloud account and a project.
 - Google Cloud SDK (`gcloud`) installed and configured.
+- Once gcloud is installed, add the gke-gcloud-auth-plugin e.g. `> gcloud components install gke-gcloud-auth-plugin`
 - Kubernetes command-line tool (`kubectl`) installed.
 - Helm installed.
 

--- a/GKE/README.md
+++ b/GKE/README.md
@@ -8,12 +8,12 @@ This guide provides instructions on how to deploy Marqo on GKE using Kubernetes 
 
 - A Google Cloud account and a project.
 - Google Cloud SDK (`gcloud`) installed and configured.
-- The gcloud plugin gke-gcloud-auth-plugin installed: ```gcloud components install gke-gcloud-auth-plugin```
+- The gcloud plugin gke-gcloud-auth-plugin installed with: ```gcloud components install gke-gcloud-auth-plugin```
 - Kubernetes command-line tool (`kubectl`) installed.
 - Helm installed.
 
 ## Notes
-Before executing the setup.sh script, ensure your GCP quotas have capacity for the following requirements:
+Before executing the setup_gke.sh script, ensure your GCP quotas have capacity for the following requirements:
 
 - vCPUs (18): Verify the quota for 18 vCPUs.
 - Persistent Disk SSD: At least 240 GB required; adjust based on your setup.

--- a/GKE/README.md
+++ b/GKE/README.md
@@ -25,8 +25,8 @@ Before executing the setup.sh script, ensure your GCP quotas have capacity for t
    Ensure you have the Marqo on GCP repository cloned to your local machine. This repository contains the necessary Helm chart and the `setup.sh` script.
 
    ```bash
-   git clone https://github.com/marqo-ai/marqo-on-gcp.git
-   cd marqo-on-gcp
+   git clone git@github.com:marqo-ai/marqo-on-kubernetes.git
+   cd marqo-on-kubernetes
    ```
 
 2. **Run the Setup Script:**

--- a/GKE/setup_gke.sh
+++ b/GKE/setup_gke.sh
@@ -1,49 +1,103 @@
 #!/bin/bash
-echo "Setting up GKE"
-date
+set -e
 
-export PROJECT_ID=<Your GCP Project ID>
-export APP_INSTANCE_NAME=<Your App Instance Name>
-# set cluster name
-export CLUSTER=<Your Cluster Name>
-# set preferred zone and region
-export REGION=<Your preferred region i.e us-central1>
-export ZONE=<Your preferred zone i.e us-central1-a>
-# INSTALL_GPU is an environment variable that indicates whether to install GPU support
-INSTALL_GPU=false
 
-gcloud services enable containerregistry.googleapis.com
-gcloud services enable container.googleapis.com
-gcloud config set project $PROJECT_ID
-gcloud config set compute/region $REGION
-gcloud config set compute/zone $ZONE
-gcloud container clusters create $CLUSTER
-gcloud container clusters get-credentials "$CLUSTER"
-# Create vespaadmin node pools.
-gcloud container node-pools create vespaadmin --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 1
-# delete the default pool, so that we have a chance to create the needed node pools
-gcloud container node-pools delete default-pool --cluster "$CLUSTER" --quiet
-# Create vesapa configserver node pools. We need 3 nodes for configserver.
-gcloud container node-pools create configserver --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 3
-# Create vespa feed node pools.
-gcloud container node-pools create vespafeed --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 1
-# Create vespa query node pools.
-gcloud container node-pools create vespaquery --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 1
-# Create vespa content node pools. We need 2 nodes for content.
-gcloud container node-pools create vespacontent --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 2
-# Non-GPU
-if [ "$INSTALL_GPU" = false ]; then
-    gcloud container node-pools create marqonodes --cluster "$CLUSTER" --machine-type n2-standard-4 --disk-type pd-standard --disk-size=100 --num-nodes 1
-fi
-# GPU
-if [ "$INSTALL_GPU" = true ]; then
-    gcloud container node-pools create marqonodes --accelerator type=nvidia-tesla-t4,count=1,gpu-driver-version=default --cluster "$CLUSTER" --machine-type n1-standard-4 --disk-type pd-standard --disk-size=100 --num-nodes 1 --image-type=UBUNTU_CONTAINERD
+# get the dir of this script and set a path to put files generated (and then read) during deploy/destroy
+THIS_FILES_DIR_PATH="$(dirname "$(readlink -f "$0")")"
+OUT_DIR="$THIS_FILES_DIR_PATH/../out"
+CLUSTER_IP_FILE_PATH="${OUT_DIR}/marqo_cluster_ip_gke.env"
+
+# source the envars
+ENVARS_FILE_PATH="${THIS_FILES_DIR_PATH}/vars.env"
+if [[ -f $ENVARS_FILE_PATH ]]; then
+  set -a
+  source $ENVARS_FILE_PATH
+  set +a
+else
+  echo "No vars.env file found. Expected at ${ENVARS_FILE_PATH}"
 fi
 
 
-helm template "${APP_INSTANCE_NAME}" chart/marqo-kubernetes --set cloudProviderMatcher=cloud.google.com/gke-nodepool,gpu_enabled=$INSTALL_GPU,override_cuda_path=$INSTALL_GPU > "${APP_INSTANCE_NAME}_manifest.yaml"
+handle_error() {
+    echo "An error occurred on line $1"
+    exit 1
+}
+trap 'handle_error $LINENO' ERR
 
-kubectl apply -f "${APP_INSTANCE_NAME}_manifest.yaml"
 
-echo "Setting completed for GKE"
-date
+destroy_marqo_k8s() {
+  echo "Destroying marqo cluster ${APP_INSTANCE_NAME} deployed on GKE"
+  gcloud container clusters delete "$CLUSTER" --quiet
+}
+
+
+deploy_marqo_k8s() {
+  echo "Deploying marqo cluster ${APP_INSTANCE_NAME} to GKE"
+
+  mkdir -p $OUT_DIR
+
+  # always execute from the top level dir
+  cd "${THIS_FILES_DIR_PATH}/.."
+
+  gcloud services enable containerregistry.googleapis.com
+  gcloud services enable container.googleapis.com
+
+  gcloud config set project $PROJECT_ID
+  gcloud config set compute/region $REGION
+  gcloud config set compute/zone $ZONE
+
+  gcloud container clusters create $CLUSTER
+  gcloud container clusters get-credentials "$CLUSTER"
+
+  # Create vespaadmin node pools.
+  gcloud container node-pools create vespaadmin --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 1
+  # delete the default pool, so that we have a chance to create the needed node pools
+  gcloud container node-pools delete default-pool --cluster "$CLUSTER" --quiet
+  # Create vesapa configserver node pools. We need 3 nodes for configserver.
+  gcloud container node-pools create configserver --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 3
+  # Create vespa feed node pools.
+  gcloud container node-pools create vespafeed --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 1
+  # Create vespa query node pools.
+  gcloud container node-pools create vespaquery --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 1
+  # Create vespa content node pools. We need 2 nodes for content.
+  gcloud container node-pools create vespacontent --cluster "$CLUSTER" --machine-type n1-standard-2 --disk-type pd-standard --disk-size=20 --num-nodes 2
+
+  # Non-GPU
+  if [ "$INSTALL_GPU" = false ]; then
+      gcloud container node-pools create marqonodes --cluster "$CLUSTER" --machine-type n2-standard-4 --disk-type pd-standard --disk-size=100 --num-nodes 1
+  fi
+  # GPU
+  if [ "$INSTALL_GPU" = true ]; then
+      gcloud container node-pools create marqonodes --accelerator type=nvidia-tesla-t4,count=1,gpu-driver-version=default --cluster "$CLUSTER" --machine-type n1-standard-4 --disk-type pd-standard --disk-size=100 --num-nodes 1 --image-type=UBUNTU_CONTAINERD
+  fi
+
+  manifest_file_path="${OUT_DIR}/${APP_INSTANCE_NAME}_manifest_gke.yaml"
+  helm template "${APP_INSTANCE_NAME}" chart/marqo-kubernetes --set cloudProviderMatcher=cloud.google.com/gke-nodepool,gpu_enabled=$INSTALL_GPU,override_cuda_path=$INSTALL_GPU > "$manifest_file_path"
+
+  kubectl apply -f "$manifest_file_path"
+
+  MARQO_CLUSTER_IP=$(kubectl get svc marqo -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "MARQO_CLUSTER_IP=$MARQO_CLUSTER_IP" > "$CLUSTER_IP_FILE_PATH"
+  export "$MARQO_CLUSTER_IP"
+
+  echo "marqo cluster ${APP_INSTANCE_NAME} deployed to GKE"
+  date
+}
+
+
+# get user input args and perform the specified action
+if (($# == 1)); then
+  user_input=$1
+  action_type=$(echo "$user_input" | tr '[:lower:]' '[:upper:]')
+  if [[ "$action_type" == "DEPLOY" ]]; then
+    deploy_marqo_k8s
+  elif [[ "$action_type" == "DESTROY" ]]; then
+    destroy_marqo_k8s
+  else
+    echo "Invalid input args. Options are: deploy or destroy."
+    exit 1
+  fi
+else
+  echo "Invalid input args. Exactly 1 required: deploy or destroy."
+  exit 1
+fi

--- a/GKE/setup_gke.sh
+++ b/GKE/setup_gke.sh
@@ -13,6 +13,7 @@ export ZONE=<Your preferred zone i.e us-central1-a>
 INSTALL_GPU=false
 
 gcloud services enable containerregistry.googleapis.com
+gcloud services enable container.googleapis.com
 gcloud config set project $PROJECT_ID
 gcloud config set compute/region $REGION
 gcloud config set compute/zone $ZONE

--- a/GKE/vars_template.env
+++ b/GKE/vars_template.env
@@ -1,0 +1,18 @@
+# create a new file in the same dir as this file called vars.env
+# and set them wth real values
+
+#PROJECT_ID=<Your GCP Project ID>
+#APP_INSTANCE_NAME=<Your App Instance Name>
+#CLUSTER=<Your Cluster Name>
+#REGION=<Your preferred region i.e us-central1>
+#ZONE=<Your preferred zone i.e us-central1-a>
+#INSTALL_GPU=false  # install GPU support? true or false
+
+# e.g. vars.env should look like:
+
+PROJECT_ID=some-project-name
+APP_INSTANCE_NAME=some-app-name
+CLUSTER=some-cluster-name
+REGION=us-central1
+ZONE=us-central1-a
+INSTALL_GPU=true


### PR DESCRIPTION
Updates to the way marqo on k8s is deployed on GKE:
- Changed setup script to auto enable GKE Kubernetes API Engine. 
- Changed setup script to have options for deploy and destroy.
- Changed setup script to read in envars so users don't edit the setup script.
- Changed setup script so envars will be re-exported in different sessions i.e. if destroying the cluster in a new session the cluster name doesn't need to be provided by the user.
- Export cluster IP address automatically as envar and to a file as permanent record so it can be used by python scripts etc.
- Updated README to reflect these changes.
- Add instructions to install required plugin.